### PR TITLE
dokku'fication : adds Gemfile* + Procfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'sinatra', '1.4.7'
+gem 'json', '2.0.2'
+gem 'net', '0.3.3'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.4)
+    i18n (0.7.0)
+    json (2.0.2)
+    minitest (5.10.1)
+    net (0.3.3)
+      activesupport
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    thread_safe (0.3.5)
+    tilt (2.0.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json (= 2.0.2)
+  net (= 0.3.3)
+  sinatra (= 1.4.7)
+
+BUNDLED WITH
+   1.13.7

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ruby server.rb


### PR DESCRIPTION
Dokku is a self-deployable Heroku-like PaaS built on Docker and Herokuish.

- Gemfile* :describes package dependencies from RubyGems
- Procfile :describes web process command

This is live at http://image-transporter.apps.allmende.io

---

This does not allow for using the `/graphviz` route, as no `digraph` or `dot` binaries will be available in the supposed environment. A `Dockerfile` based deployment or a custom `herokuish` buildpack may help to get over this insufficiency of the oversimple Gem- + Procfile metadata.